### PR TITLE
GitHub workflow to handle deployments of echo server

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,23 @@
+name: Build docker image
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  deploy:
+    name: Build the docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ github.ref_name }}"

--- a/.github/workflows/tag-staging.yml
+++ b/.github/workflows/tag-staging.yml
@@ -1,0 +1,39 @@
+name: Staging environment management
+on:
+  pull_request:
+    types: [opened, closed, synchronize, reopened, labeled, unlabeled]
+jobs:
+  tag:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-ci') }}
+    name: Tag staging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      # Retrieve the branch name when there is a `staging` label
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
+        id: extract_branch
+      # Tag the current commit with `staging-BRANCH_NAME` when there is a `staging` label
+      - name: "Tag staging"
+        uses: eKee-io/git-tag-action@fix-not-a-git-dir
+        if:
+          ${{ !contains(fromJson('["unlabeled", "closed"]'), github.event.action)
+          && contains(github.event.pull_request.labels.*.name, 'staging') }}
+        env:
+          TAG: staging-${{ steps.extract_branch.outputs.branch }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.extract_branch.outputs.branch }}
+      # Delete the `staging-BRANCH_NAME` tag if the PR is closed or unlabeled
+      - name: "Untag staging"
+        uses: eKee-io/git-tag-action@fix-not-a-git-dir
+        if: ${{ contains(github.event.action, 'closed') ||
+          (contains(github.event.action, 'unlabeled')
+          && !contains(github.event.pull_request.labels.*.name, 'staging')) }}
+        env:
+          TAG: staging-${{ steps.extract_branch.outputs.branch }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.extract_branch.outputs.branch }}
+          DELETE: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+## Build
+FROM golang:1.19-buster AS build
+
+WORKDIR /app
+
+
+COPY echo-server/go.mod ./
+RUN go mod download
+
+COPY echo-server/*.go ./
+
+RUN go build -o /echo-server
+
+## Deploy
+FROM gcr.io/distroless/base-debian10
+
+WORKDIR /
+
+COPY --from=build /echo-server /echo-server
+
+EXPOSE 8080
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/echo-server"]

--- a/echo-server/README.md
+++ b/echo-server/README.md
@@ -1,0 +1,4 @@
+# echo-server
+
+echo-server exposes a server listening on :8080 and echoing
+everything it receives

--- a/echo-server/echo-server.go
+++ b/echo-server/echo-server.go
@@ -1,0 +1,28 @@
+// echo-server exposes a server listening on :8080 and echoing
+// everything it receives
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+)
+
+type EchoHandler struct{}
+
+func (h *EchoHandler) ServeHTTP(w http.ResponseWriter, rq *http.Request) {
+	_, bodyE := io.Copy(w, rq.Body)
+	if bodyE != nil {
+		_, writeE := w.Write([]byte("failed to copy the body"))
+		if writeE != nil {
+			log.Printf("failed to write error to response body: %s", writeE)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func main() {
+	http.Handle("/", &EchoHandler{})
+	log.Println("listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/echo-server/go.mod
+++ b/echo-server/go.mod
@@ -1,0 +1,3 @@
+module github.com/Dot-H/simple-staging-env-ex/echo-server
+
+go 1.19


### PR DESCRIPTION
# What

- Add the [echo-server](./echo-server) go app
- Add the [Dockerfile](./Dockerfile) permitting to build the echo-server
- Add the github workflows to:
  - Build the docker image upon tag events
  - Tag a commit when the label `staging` is on
  - Untag a commit when the label `staging` is removed