### PR TITLE
Handle multiple staging instances

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,7 +1,5 @@
 name: Build docker image
 on:
-  release:
-    types: [published, prereleased]
   workflow_run:
     workflows: ["Release staging version"]
     types:

--- a/echo-server/echo-server.go
+++ b/echo-server/echo-server.go
@@ -6,10 +6,27 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 )
 
+var ENV_USERNAME = "ECHO_SERVER_USERNAME"
+var USERNAME = ""
+
+func init() {
+	hasUsername := false
+	if USERNAME, hasUsername = os.LookupEnv(ENV_USERNAME); !hasUsername {
+		log.Fatalf("missing mandatory environment variable %q", ENV_USERNAME)
+	}
+}
+
+// EchoHandler implements http.Handler to echo the request body into
+// the response.
+//
+// See EchoHandler.ServeHTTP for more details.
 type EchoHandler struct{}
 
+// ServeHTTP copies back the request body into the response and adds
+// the header X-ECHO-SERVER-USERNAME in it
 func (h *EchoHandler) ServeHTTP(w http.ResponseWriter, rq *http.Request) {
 	_, bodyE := io.Copy(w, rq.Body)
 	if bodyE != nil {
@@ -19,6 +36,8 @@ func (h *EchoHandler) ServeHTTP(w http.ResponseWriter, rq *http.Request) {
 		}
 		w.WriteHeader(http.StatusInternalServerError)
 	}
+
+	rq.Response.Header.Add("X-ECHO-SERVER-USERNAME", USERNAME)
 }
 
 func main() {

--- a/k8s/staging-env/templates/_helpers.tpl
+++ b/k8s/staging-env/templates/_helpers.tpl
@@ -2,25 +2,14 @@
 Expand the name of the chart.
 */}}
 {{- define "staging-env.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Values.name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+Expand the name of the chart and ignore potential `.nameOverride`
 */}}
-{{- define "staging-env.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- define "staging-env.strictName" -}}
+{{- $.Values.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/* Tag for the echo-server docker image */}}
@@ -61,15 +50,4 @@ Selector labels
 {{- define "staging-env.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "staging-env.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "staging-env.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "staging-env.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
 {{- end }}

--- a/k8s/staging-env/templates/deployment.yaml
+++ b/k8s/staging-env/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "staging-env.fullname" . }}
+  name: {{ include "staging-env.name" . }}
   labels:
     {{- include "staging-env.labels" . | nindent 4 }}
 spec:
@@ -22,3 +22,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          env:
+          - name: ECHO_SERVER_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "staging-env.strictName" . }}-secret
+                key: username

--- a/k8s/staging-env/templates/ingress.yaml
+++ b/k8s/staging-env/templates/ingress.yaml
@@ -1,6 +1,5 @@
-{{- if not .Values.staging.tag }} # Not in staging mode
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "staging-env.fullname" . -}}
+{{- $name := include "staging-env.name" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
@@ -10,7 +9,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $name }}
   labels:
     {{- include "staging-env.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -32,25 +31,18 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- if not .Values.staging.tag }} # Not in staging mode
     - host: "echo.alx-b.com"
+    {{- else }} # Not in staging mode
+    - host: "echo.{{ $name }}.alx-b.com"
+    {{- end }} # Not in staging mode
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ $fullName }}
+                name: {{ $name }}
                 port:
                   number: {{ $svcPort }}
-    - host: "echo.staging.alx-b.com"
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: staging-{{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-{{- end }}
 {{- end }}

--- a/k8s/staging-env/templates/secret.yaml
+++ b/k8s/staging-env/templates/secret.yaml
@@ -1,0 +1,11 @@
+---
+{{- if not .Values.staging.tag }} # Not in staging mode
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "staging-env.strictName" . }}-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+{{- end }} # Not in staging mode

--- a/k8s/staging-env/templates/service.yaml
+++ b/k8s/staging-env/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "staging-env.fullname" . }}
+  name: {{ include "staging-env.name" . }}
   labels:
     {{- include "staging-env.labels" . | nindent 4 }}
 spec:

--- a/k8s/staging-env/values-staging.yaml
+++ b/k8s/staging-env/values-staging.yaml
@@ -9,9 +9,11 @@
 
 # If touching this name, you will need to patch the "Ingress" deployment in order
 # to patch the backend serviceName for the "staging.*" hosts
-fullnameOverride: "staging-echo-server"
+nameOverride: "staging-echo-server"
 
 image:
+  # Always pull in order to retrieve the latest version of the staging
+  # element
   pullPolicy: Always
 
 # Values permitting to know which staging tag should be used and which deployments

--- a/k8s/staging-env/values.yaml
+++ b/k8s/staging-env/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+name: echo-server
+nameOverride: ""
 replicaCount: 1
 
 staging:
@@ -12,9 +14,6 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "main"
-
-nameOverride: ""
-fullnameOverride: "echo-server"
 
 service:
   type: NodePort


### PR DESCRIPTION
# What

- Make deployment handle multiple staging instances at once
- Show an example of how to use a production resource inside a staging one without duplicating 

# How

## Make deployment handle multiple staging instances at once

- Deploy an ingress per staging chart (:warning: this does not mean a *controller*)
- Use the `name` variable rather than the `fullName` in order to make things simplier

## Show an example of how to use a production resource inside a staging one without duplicating 

- Add a secret and use show the usage of the `strictName` template in the configuration
- Make use of the secret in the `echo-server.go`